### PR TITLE
Bump to Stream UI Component 4.21.0

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -24,7 +24,7 @@ ext.versions = [
         archCompomentVersion: '2.1.0',
 
         // stream chat SDK
-        streamChatUIVersion : '4.20.0',
+        streamChatUIVersion : '4.21.0',
 
         // binding
         bindablesVersion    : '1.0.9',


### PR DESCRIPTION
## Guidelines
Bump to Stream UI Component 4.21.0.

### Release Note
[4.21.0](https://github.com/GetStream/stream-chat-android/releases).