### PR TITLE
Bump Stream SDK to 4.22.0

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -25,7 +25,7 @@ ext.versions = [
         archCompomentVersion: '2.1.0',
 
         // stream chat SDK
-        streamChatUIVersion : '4.21.0',
+        streamChatUIVersion : '4.22.0',
 
         // binding
         bindablesVersion    : '1.0.9',


### PR DESCRIPTION
## Guidelines
Bump Stream SDK to [4.22.0](https://github.com/GetStream/stream-chat-android/releases/tag/4.22.0).