### PR TITLE
Bump Stream chat SDK to 5.1.0 and update dependencies

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -5,13 +5,13 @@ ext.versions = [
         versionName         : '1.0.5',
 
         // gradle plugins
-        gradleBuildTool     : '7.1.0',
-        spotlessGradle      : '6.2.1',
+        gradleBuildTool     : '7.1.2',
+        spotlessGradle      : '6.3.0',
         googleService       : '4.3.10',
         ktlint              : '0.40.0',
 
         // kotlin
-        kotlin              : '1.5.32',
+        kotlin              : '1.6.10',
 
         // support library
         materialVersion     : '1.5.0',
@@ -25,7 +25,7 @@ ext.versions = [
         archCompomentVersion: '2.1.0',
 
         // stream chat SDK
-        streamChatUIVersion : '4.30.1',
+        streamChatUIVersion : '5.1.0',
 
         // binding
         bindablesVersion    : '1.0.9',
@@ -39,13 +39,13 @@ ext.versions = [
         // network
         retrofitVersion     : '2.9.0',
         okhttpVersion       : '4.9.1',
-        sandwichVersion     : '1.2.1',
+        sandwichVersion     : '1.2.4',
 
         // moshi
-        moshiVersion        : '1.12.0',
+        moshiVersion        : '1.13.0',
 
         // coroutines
-        coroutinesVersion   : '1.5.2',
+        coroutinesVersion   : '1.6.0',
 
         // image loading
         coilVersion         : '1.4.0',


### PR DESCRIPTION
## Overview
Bump Stream chat SDK to 5.1.0 and update dependencies.