### PR TITLE
CI: add least-privilege permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -23,7 +23,7 @@ jobs:
           java-version: 11
 
       - name: Cache Gradle and wrapper
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -9,7 +9,6 @@ on:
 permissions:
   actions: write
   contents: read
-  pull-requests: read
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- Add explicit least-privilege `permissions` blocks to workflow files flagged by CodeQL.
- Scopes derived from workflow operations (build, artifacts, Danger, release git push).
- Resolves **1** open `actions/missing-workflow-permissions` alerts.

## Linear
- Parent: [APPSEC-164](https://linear.app/stream/issue/APPSEC-164)

## Test plan
- [ ] CI green
- [ ] Code scanning alerts close after merge
